### PR TITLE
Running through docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,21 +46,8 @@ Considering that we are talking about tiny sensors, IPv6 might actually be
 really useful here.
 
 ## Installation/Build
-### Manually:
-1) docker run -it -p 1883:1883 --name=mosquitto  toke/mosquitto as recommended
-2) go get dependencies for the eclipse "paho" mqtt library:
-```
-go get golang.org/x/net/websocket
-go get golang.org/x/net/proxy
-```
-3) get the main library to handle MQTT:
-```
-go get github.com/eclipse/paho.mqtt.golang
-```
-4) run "go build" in the service/, sensors/ and heater/ subdirectory
-5) start ``./service``, ``./sensors``, ``./heater`` in the respective
-subdirectory, it'll just run. Watch them in three different terminal
-publishing, subscribing and heating. :)
+### via docker-compose:
+Run: `docker-compose up --build` from the root of this repository
 
 ### Use the Makefile to build locally:
 You'd still nedd the broker up and running:

--- a/README.md
+++ b/README.md
@@ -66,39 +66,6 @@ subdirectory, it'll just run. After that, you can just watch the three apps
 subscribing, publishing and heating. :)
 
 
-### Build and run via Docker containers
-In order to allow connections to the broker properly, the containers need to
-be started with --net=host:
-
-```
-docker run -it -p 1883:1883 -p 9001:9001 --name=mosquitto --net=host toke/mosquitto
-```
-
-The heating service containers can be build like this:
-
-```
-docker build -t service .
-docker run -ti --net=host service <containerid>
-```
-
-```
-docker build -t heater .
-docker run -ti --net=host heater <containerid>
-```
-
-```
-docker build -t sensors .
-docker run -ti --net=host service <containerid>
-```
-
-If you start them in three different terminals, you can watch them publishing,
-subscribing and heating. :)
-
-There is also a basic docker-compose file available which at the moment has
-the usal "distributed" problem: there is no quarantee which container gets
-started and run in what order and they are not waiting for each other to
-finish. The three tiny apps are not yet prepared with proper delayed retries
-to actually wait themselves until they reach the broker.
 
 (Deployment to Kubernetes has the same problem - there is however the concept
 of a pre- and post hook in order to do something before and after a pod has

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,5 +16,5 @@ services:
 
   sensors:
     build:
-      context: ./heater
+      context: ./sensors
     network_mode: "host"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.2'
 services:
   mosquitto:
     image: toke/mosquitto
@@ -8,19 +8,16 @@ services:
     build:
       context: ./service
       dockerfile: Dockerfile
-    image: golang:latest
     network_mode: "host"
 
   heater:
     build:
       context: ./heater
       dockerfile: Dockerfile
-    image: golang:latest
     network_mode: "host"
 
   sensors:
     build:
       context: ./heater
       dockerfile: Dockerfile
-    image: golang:latest
     network_mode: "host"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,13 +8,16 @@ services:
     build:
       context: ./service
     network_mode: "host"
+    restart: on-failure
 
   heater:
     build:
       context: ./heater
     network_mode: "host"
+    restart: on-failure
 
   sensors:
     build:
       context: ./sensors
     network_mode: "host"
+    restart: on-failure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,17 +7,14 @@ services:
   service:
     build:
       context: ./service
-      dockerfile: Dockerfile
     network_mode: "host"
 
   heater:
     build:
       context: ./heater
-      dockerfile: Dockerfile
     network_mode: "host"
 
   sensors:
     build:
       context: ./heater
-      dockerfile: Dockerfile
     network_mode: "host"


### PR DESCRIPTION
This fixes `docker-compose up` and therefore allows others to run the challenge with a minimal effort

* Make docker-compose the default run option
* Fix build context for the `sensors` service
* Use compose 3.2
* Restart service containers when they fail - since they're designed to fail fast when they can't reach the MQTT instance, we can use that fact to fix the dependency problem in distributed system - If MQTT hasn't manage to start before services, they'll simply fail, get restarted, re-attempt connecting to a broker.